### PR TITLE
Post-method for reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 media/
 */migrations
+static/

--- a/api/views.py
+++ b/api/views.py
@@ -78,3 +78,6 @@ class ReviewViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return self.get_product().reviews.all()
+
+    def perform_create(self, serializer):
+        serializer.save(product=self.get_product(), customer=self.request.user)


### PR DESCRIPTION
Добавила метод во views для создания пост-запроса по отзывам по эндпойнту products/1/reviews/. Методы put, patch и delete переопределять не нужно, они доступны в базовом вьюсете для уже созданного отзыва.